### PR TITLE
fix: 🐛 TODO-133: ID in modal share now have UpperCase

### DIFF
--- a/src/components/modal-share/index.tsx
+++ b/src/components/modal-share/index.tsx
@@ -52,7 +52,7 @@ const ModalShare: React.FC<IProps> = ({id, open, onClose}) => {
                 <Icon name="ico-copy" />
               </Button>
             }
-            value={id}
+            value={id.toUpperCase()}
             readOnly
           />
         </div>


### PR DESCRIPTION
![Screenshot from 2022-09-15 11-16-08](https://user-images.githubusercontent.com/99172799/190313217-0a4d2f72-a176-402e-91a0-94cf560790a1.png)
