### PR TITLE
TD-361: Clear local storage after logout

### DIFF
--- a/src/components/common/account/index.tsx
+++ b/src/components/common/account/index.tsx
@@ -6,6 +6,7 @@ import {ROUTES} from '@/configs/routes.config';
 import Icon from '@/core-ui/icon';
 import {IUserResponse} from '@/data/api/types/user.type';
 import useModals from '@/states/modals/use-modals';
+import LocalStorage from '@/utils/local-storage';
 
 import AssigneeIcon from '../assignee-icon';
 import style from './style.module.scss';
@@ -57,6 +58,7 @@ const Account: FC<IAccountProps> = props => {
                     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
                     handleClosePopover && handleClosePopover();
                     router.push(ROUTES.LOGIN);
+                    LocalStorage.clearAll();
                   }}
                 >
                   Log Out

--- a/src/states/filter/slice.ts
+++ b/src/states/filter/slice.ts
@@ -48,7 +48,7 @@ const filterSlice = createSlice({
       state.nameFilter = payload.toLowerCase();
     },
     getFilterTaskByName: state => {
-      state.filterTasks = state.filterTasks.filter(e => e.name.toLowerCase().includes(state.nameFilter));
+      state.filterTasks = state.filterTasks?.filter(e => e.name.toLowerCase().includes(state.nameFilter));
     }
   }
 });

--- a/src/utils/local-storage.ts
+++ b/src/utils/local-storage.ts
@@ -9,6 +9,7 @@ const LocalStorage = {
   accessToken: generateLocalStorage('accessToken'),
   listId: generateLocalStorage('listId'),
   previousPage: generateLocalStorage('previousPage'),
-  checkPage: generateLocalStorage('checkPage')
+  checkPage: generateLocalStorage('checkPage'),
+  clearAll: () => localStorage.clear()
 };
 export default LocalStorage;


### PR DESCRIPTION
<img width="1087" alt="image" src="https://github.com/abc-software-solutions-company/todo-list-website/assets/99172799/8b3d8dec-9a75-46e1-9045-faafda28c860">

Clear any unnecessary localstorage value, prevent glitching when routing to private list after you logout and login other account